### PR TITLE
added hClassName prop

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import { checkHeadingLevels, H, Level, useLevel } from "./index";
+import { checkHeadingLevels, H, Level, useHClassName, useLevel } from "./index";
 
 test("H renders an H1 be default", () => {
   const { getByText } = render(<H>Foo</H>);
@@ -61,6 +61,74 @@ test("Multiple h1s are detected (dev mode)", () => {
   const multipleH1s = [1, 2, 3, 1];
   expect(() => checkHeadingLevels(multipleH1s)).toThrow();
 });
+
+test("hClassName sets className on every decendant H elements", () => {
+  const { getAllByText } = render(
+    <Level hClassName="h">
+      <H>Foo</H>
+      <H>Foo</H>
+      <Level>
+        <H>Foo</H>
+      </Level>
+    </Level>
+  )
+  
+  const hClassNames = getAllByText("Foo").map((el) => el.className);
+  expect(hClassNames).toEqual(["h", "h", "h"]);
+})
+
+test("H elements can have className", () => {
+	const { getByText } = render(
+		<Level>
+			<H className="foo">Bar</H>
+		</Level>
+	);
+
+	const headingEl = getByText("Bar");
+	expect(headingEl.className).toBe("foo");
+});
+
+test("H element's className does not override hClassName", () => {
+	const { getByText } = render(
+		<Level hClassName="foo">
+			<H className="bar">Baz</H>
+		</Level>
+	);
+
+	const headingEl = getByText("Baz");
+	expect(headingEl.className).toBe("foo bar");
+});
+
+test("Child's hClassName overrides the parent", () => {
+	const { getByText } = render(
+		<Level hClassName="foo">
+			<Level hClassName="bar">
+				<H>Baz</H>
+			</Level>
+		</Level>
+	);
+
+	const headingEl = getByText("Baz");
+	expect(headingEl.className).toBe("bar");
+});
+
+test("useHClassName returns the correct className", () => {
+  function Test() {
+    const className = useHClassName();
+
+    expect(className).toBe("foo");
+
+    return null;
+  }
+
+  render(
+    <Level hClassName="foo">
+      <Test />
+    </Level>
+  );
+});
+
+
 
 describe("in production mode", () => {
   let oldEnv;


### PR DESCRIPTION
despite my initial thoughts, I've decided it's best not to have the library choose a default className for H elements. Instead, users can define their own `hClassName` on the Top-Level `Level` component and it will provide the same className for every decendant H elements. It's also possible to override or remove classNames for any sub-tree by redefining `hClassName` on a child `Level` component.

This update should not break existing apps. 

I'll change the readme too if everything's acceptable, although I'm not too sure about the naming.